### PR TITLE
Investigate GitHub Issue #1

### DIFF
--- a/api/index.py
+++ b/api/index.py
@@ -1341,7 +1341,10 @@ def handle_mcp_request(body: dict) -> dict:
                     "properties": {
                         "threats": {
                             "type": "array",
-                            "items": {"type": "object"},
+                            "items": {
+                                "type": "object",
+                                "additionalProperties": true
+                            },
                             "description": "Array of threat objects"
                         },
                         "priority_filter": {
@@ -1361,7 +1364,10 @@ def handle_mcp_request(body: dict) -> dict:
                     "properties": {
                         "threats": {
                             "type": "array",
-                            "items": {"type": "object"},
+                            "items": {
+                                "type": "object",
+                                "additionalProperties": true
+                            },
                             "description": "Array of threat objects (used for context)"
                         },
                         "max_depth": {
@@ -1386,11 +1392,15 @@ def handle_mcp_request(body: dict) -> dict:
                     "properties": {
                         "threats": {
                             "type": "array",
-                            "items": {"type": "object"},
+                            "items": {
+                                "type": "object",
+                                "additionalProperties": true
+                            },
                             "description": "Array of threat objects"
                         },
                         "scoring_guidance": {
                             "type": "object",
+                            "additionalProperties": true,
                             "description": "Optional guidance for scoring adjustments"
                         }
                     },
@@ -1405,7 +1415,10 @@ def handle_mcp_request(body: dict) -> dict:
                     "properties": {
                         "threats": {
                             "type": "array",
-                            "items": {"type": "object"},
+                            "items": {
+                                "type": "object",
+                                "additionalProperties": true
+                            },
                             "description": "Array of threat objects"
                         },
                         "test_type": {
@@ -1430,22 +1443,34 @@ def handle_mcp_request(body: dict) -> dict:
                     "properties": {
                         "threat_model": {
                             "type": "array",
-                            "items": {"type": "object"},
+                            "items": {
+                                "type": "object",
+                                "additionalProperties": true
+                            },
                             "description": "Array of threat objects"
                         },
                         "mitigations": {
                             "type": "array",
-                            "items": {"type": "object"},
+                            "items": {
+                                "type": "object",
+                                "additionalProperties": true
+                            },
                             "description": "Optional array of mitigation strategies"
                         },
                         "dread_scores": {
                             "type": "array",
-                            "items": {"type": "object"},
+                            "items": {
+                                "type": "object",
+                                "additionalProperties": true
+                            },
                             "description": "Optional array of DREAD scores"
                         },
                         "attack_trees": {
                             "type": "array",
-                            "items": {"type": "object"},
+                            "items": {
+                                "type": "object",
+                                "additionalProperties": true
+                            },
                             "description": "Optional array of attack trees"
                         },
                         "include_sections": {
@@ -1466,11 +1491,15 @@ def handle_mcp_request(body: dict) -> dict:
                     "properties": {
                         "threat_model": {
                             "type": "array",
-                            "items": {"type": "object"},
+                            "items": {
+                                "type": "object",
+                                "additionalProperties": true
+                            },
                             "description": "Array of threat objects to validate"
                         },
                         "app_context": {
                             "type": "object",
+                            "additionalProperties": true,
                             "description": "Application context information"
                         }
                     },


### PR DESCRIPTION
Resolves issue #1 where schema validation errors occurred when calling tools with object parameters (particularly generate_threat_report).

**Problem:**
JSON Schema validators were rejecting object parameters because `{"type": "object"}` without `additionalProperties: true` was too restrictive. Strict validators interpreted this as allowing only empty objects {}.

**Solution:**
Added `"additionalProperties": true` to all object type definitions in tool schemas to allow objects with any properties. This aligns with the framework-based design where the MCP server provides structure and guidance, while LLM clients provide the actual threat data in flexible formats.

**Tools Fixed:**
- generate_threat_mitigations
- create_threat_attack_trees
- calculate_threat_risk_scores (threats + scoring_guidance)
- generate_security_tests
- generate_threat_report (threat_model, mitigations, dread_scores, attack_trees)
- validate_threat_coverage (threat_model + app_context)

🤖 Generated with [Claude Code](https://claude.com/claude-code)