### PR TITLE
feat: scaffold STRIDE threat-modelling skill (#10)

### DIFF
--- a/skills/stride-threat-modelling/SKILL.md
+++ b/skills/stride-threat-modelling/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: stride-threat-modelling
+description: >-
+  Produce a consistent, house-style STRIDE threat model and report for a
+  described system — enumerate threats STRIDE-per-element across trust
+  boundaries and data flows, score them with DREAD, then recommend mitigations,
+  attack trees, security tests, and a coverage check. Use when the user wants a
+  threat model, STRIDE analysis, security risk assessment, DREAD scoring, an
+  attack tree, or a threat report for an application, architecture, feature, or
+  repository.
+license: GPL-3.0-or-later
+---
+
+# STRIDE Threat Modelling
+
+Turn a system description into a rigorous, house-style STRIDE threat model and
+report. The methodology, rubrics, and report craft live in this skill — it runs
+on your own model with **no API key and no dependency on the STRIDE-GPT MCP
+server**. (The hosted MCP server remains only as an optional add-by-URL
+distribution channel; this skill stands on its own.)
+
+The discipline is **per-element**: enumerate threats systematically for every
+element of the system — each process, data store, data flow, and external
+entity, and especially each **trust boundary** they cross — rather than
+brainstorming threats at large. Per-element coverage is what makes two runs of
+this skill land in the same place.
+
+## Inputs to gather
+
+Ask for whatever is missing before enumerating:
+
+- **System description** — what it does, main components, and how they connect.
+- **App type** — e.g. web app, API/microservices, mobile, cloud service,
+  AI/ML system, IoT/embedded, desktop.
+- **Authentication methods** — how identities are established.
+- **Internet-facing?** — is the attack surface public or internal-only.
+- **Sensitive data** — what the system holds or processes (PII, credentials,
+  financial, health, secrets).
+
+If the user points you at a **repository** instead of a written description,
+follow [`references/repo-analysis.md`](references/repo-analysis.md) to extract
+these inputs efficiently before you start, then continue the workflow below.
+
+## Workflow
+
+Run these in order. Each step names its **done-when** condition — do not move on
+until it holds.
+
+1. **Scope the system.** Restate the architecture in your own words and list the
+   elements and trust boundaries you will analyse (processes, data stores, data
+   flows, external entities). *Done when* every component in the description maps
+   to at least one listed element, and every boundary where trust changes is
+   named.
+
+2. **Enumerate threats — STRIDE-per-element.** For each element and boundary,
+   walk all six STRIDE categories (Spoofing, Tampering, Repudiation, Information
+   Disclosure, Denial of Service, Elevation of Privilege) and select the threats
+   that genuinely apply to *this* system. Draw on the extended threat domains
+   relevant to the app type. Give each threat a stable ID, its STRIDE category,
+   and a specific description. See
+   [`references/stride-framework.md`](references/stride-framework.md). *Done
+   when* every element has been considered against all six categories (record
+   "not applicable" explicitly rather than skipping), and no threat is generic
+   boilerplate — each names a concrete element or flow.
+
+3. **Score with DREAD.** Score each threat on Damage, Reproducibility,
+   Exploitability, Affected Users, and Discoverability (1–10 each), sum to a
+   0–50 total, and map to a Critical/High/Medium/Low priority. Justify every
+   score from the specific threat and system context. Use the calibration
+   bands and worked examples in
+   [`references/dread-scoring.md`](references/dread-scoring.md). *Done when*
+   every threat has five justified sub-scores, a total, and a priority.
+
+4. **Recommend mitigations.** For each threat (highest priority first), give
+   specific, actionable controls classified Preventive / Detective / Corrective,
+   with an implementation difficulty and priority, following defence-in-depth.
+   See [`references/mitigations.md`](references/mitigations.md). *Done when* every
+   High/Critical threat has at least one concrete, implementable mitigation.
+
+5. **(Optional) Attack trees.** When the user wants attack paths visualised, or a
+   high-value threat warrants decomposition, build attack trees per
+   [`references/attack-trees.md`](references/attack-trees.md). *Done when* each
+   requested tree decomposes a root goal into sub-goals, methods, and
+   prerequisites.
+
+6. **(Optional) Security tests.** When the user wants validation, generate test
+   cases (default Gherkin) that prove each mitigation works, per
+   [`references/security-tests.md`](references/security-tests.md). *Done when*
+   each targeted threat has at least one positive and one negative test.
+
+7. **Validate coverage.** Before reporting, audit the model against
+   [`references/coverage-validation.md`](references/coverage-validation.md):
+   every STRIDE category considered for every trust boundary and data flow,
+   threats specific and actionable, high-risk threats given due attention. *Done
+   when* each identified gap is either filled or explicitly noted as
+   out-of-scope with a reason.
+
+8. **Assemble the report.** Produce the deliverable in the house style defined by
+   [`references/report-format.md`](references/report-format.md) — Markdown by
+   default. *Done when* the report contains every requested section and each fact
+   traces back to a threat, score, or mitigation from the steps above.
+
+## Output
+
+Default output is **Markdown**, structured per
+[`references/report-format.md`](references/report-format.md). Keep the tone
+professional and the recommendations specific to the described system — no
+generic advice that would read the same for any application.
+
+## Reference files
+
+Consulted on demand — load the one the current step points to:
+
+- [`references/stride-framework.md`](references/stride-framework.md) — STRIDE
+  categories, per-element method, and extended threat domains by app type.
+- [`references/dread-scoring.md`](references/dread-scoring.md) — the DREAD 1–10
+  scales, calibration bands, risk-level mapping, and worked examples.
+- [`references/mitigations.md`](references/mitigations.md) — the mitigation
+  classification and prioritisation framework.
+- [`references/attack-trees.md`](references/attack-trees.md) — attack-tree
+  structure, common patterns, and text / Mermaid / JSON formats.
+- [`references/security-tests.md`](references/security-tests.md) — security test
+  types, formats, and coverage areas.
+- [`references/coverage-validation.md`](references/coverage-validation.md) — the
+  completeness checklist and common coverage gaps.
+- [`references/report-format.md`](references/report-format.md) — the house-style
+  report structure.
+- [`references/repo-analysis.md`](references/repo-analysis.md) — staged approach
+  for extracting threat-modelling inputs from a code repository.

--- a/skills/stride-threat-modelling/references/attack-trees.md
+++ b/skills/stride-threat-modelling/references/attack-trees.md
@@ -1,0 +1,65 @@
+# Attack Trees
+
+An attack tree is a hierarchical representation of how a threat could be
+realised. Build one when the user asks to visualise attack paths, or when a
+high-value threat warrants decomposition.
+
+## Structure
+
+- **Root goal** — the primary objective the attacker wants to achieve.
+- **Sub-goals** — intermediate objectives that support the root goal.
+- **Attack methods** — specific techniques or vulnerabilities that enable each
+  sub-goal.
+- **Prerequisites** — conditions or access required for each attack method.
+
+Use **AND** / **OR** nodes: OR means any child suffices; AND means all children
+are required. Start from the high-level goal and decompose into concrete attack
+vectors and their prerequisites.
+
+## Common patterns
+
+- **Reconnaissance** — information gathering, system enumeration, social engineering.
+- **Initial access** — phishing, credential stuffing, vulnerability exploitation.
+- **Privilege escalation** — local exploits, credential theft, authorization bypass.
+- **Persistence** — backdoors, scheduled tasks, registry modification.
+- **Exfiltration** — data staging, command and control, covert channels.
+
+## Output formats
+
+**Text** — ASCII tree using `└──` and `├──`:
+
+```
+Goal: Steal API Keys
+├── [OR] Exploit Public Deployment
+│   ├── Access public instance
+│   └── Extract from browser
+└── [OR] Exploit Local Deployment
+    └── Read .env file
+```
+
+**Mermaid** — graph syntax for rendered diagrams:
+
+```mermaid
+graph TD
+    A[Steal API Keys] --> B{OR}
+    B --> C[Exploit Public]
+    B --> D[Exploit Local]
+    C --> E[Access instance]
+    C --> F[Extract from browser]
+    D --> G[Read .env file]
+```
+
+**JSON** — structured representation:
+
+```json
+{
+  "root": "Steal API Keys",
+  "type": "OR",
+  "children": [
+    { "goal": "Exploit Public Deployment", "methods": ["Access instance", "Extract from browser"] }
+  ]
+}
+```
+
+Default to providing both the text and Mermaid forms unless the user asks for a
+specific format.

--- a/skills/stride-threat-modelling/references/coverage-validation.md
+++ b/skills/stride-threat-modelling/references/coverage-validation.md
@@ -1,0 +1,35 @@
+# Coverage Validation
+
+Before assembling the report, audit the threat model for completeness. The goal
+is to catch what was missed, not to re-list what was found.
+
+## Per-category check
+
+Verify each STRIDE category has been considered for every trust boundary and
+data flow:
+
+- **S — Spoofing** — all identity-related threats considered.
+- **T — Tampering** — all data/code integrity threats considered.
+- **R — Repudiation** — all accountability threats considered.
+- **I — Information Disclosure** — all confidentiality threats considered.
+- **D — Denial of Service** — all availability threats considered.
+- **E — Elevation of Privilege** — all authorization threats considered.
+
+## Validation criteria
+
+- **Completeness** — all STRIDE categories addressed for each trust boundary.
+- **Specificity** — threats are specific to the application context, not generic.
+- **Actionability** — threats lead to implementable mitigations.
+- **Risk alignment** — high-risk threats receive appropriate attention.
+
+## Common gaps
+
+Look specifically for these — they are where models routinely fall short:
+
+- **Trust boundaries** — missing threats at component interfaces.
+- **Data flows** — insufficient consideration of data in transit.
+- **Privileged operations** — inadequate coverage of admin functions.
+- **Error conditions** — missing threat consideration for edge cases.
+
+Every gap you find must be either filled or explicitly recorded as out-of-scope
+with a reason before you report.

--- a/skills/stride-threat-modelling/references/dread-scoring.md
+++ b/skills/stride-threat-modelling/references/dread-scoring.md
@@ -1,0 +1,77 @@
+# DREAD Risk Scoring
+
+DREAD prioritises threats by scoring five factors from **1–10** each. Sum the
+five for a **0–50 total**, then map to a priority. Justify every sub-score from
+the specific threat and system context — a score without a rationale is not done.
+
+## The five criteria
+
+| Factor | Question | Scale (1 → 10) | Consider |
+|--------|----------|----------------|----------|
+| **Damage** | How bad would an attack be? | minimal damage → complete system compromise | financial impact, data sensitivity, regulatory consequences, business continuity |
+| **Reproducibility** | How easy is it to reproduce? | very difficult → very easy | attack complexity, required tools/skills, environmental dependencies |
+| **Exploitability** | How much work to launch? | very hard → very easy | technical skill required, time investment, resource requirements |
+| **Affected Users** | How many users impacted? | few users → all users | user base size, impact scope, cascading effects |
+| **Discoverability** | How easy to discover? | very hard → very easy | visibility of attack surface, documentation availability, common vulnerability |
+
+## Risk levels (from the total)
+
+| Total | Priority | Meaning |
+|-------|----------|---------|
+| 40–50 | **Critical** | Immediate action required |
+| 30–39 | **High** | High priority for remediation |
+| 20–29 | **Medium** | Medium priority |
+| 5–19 | **Low** | Low priority but should be addressed |
+
+## Calibration bands
+
+Anchor each sub-score against these bands rather than guessing:
+
+**Damage** — 1–3 minimal (single user, non-critical, easily recoverable) ·
+4–6 moderate (multiple users, important functionality, recovery required) ·
+7–9 high (most users, critical functionality, difficult recovery) ·
+10 catastrophic (complete compromise, all users, irrecoverable).
+
+**Reproducibility** — 1–3 difficult (specific timing, race conditions, rare
+circumstances) · 4–6 moderate (specific configuration or user actions) ·
+7–9 easy (reproducible with standard tools and documentation) ·
+10 always (100% reproducible, deterministic).
+
+**Exploitability** — 1–3 expert (deep expertise, custom tools, significant time) ·
+4–6 intermediate (moderate skill, some tool customization) · 7–9 basic (standard
+tools/scripts available, minimal expertise) · 10 trivial (no skill required,
+fully automated tools exist).
+
+**Affected Users** — 1–3 few (< 10% of users, isolated) · 4–6 some (10–50%,
+limited scope) · 7–9 most (50–90%, widespread) · 10 all (100%, system-wide).
+
+**Discoverability** — 1–3 hidden (source review, insider knowledge, deep
+analysis) · 4–6 obscure (investigation, testing, or documentation review) ·
+7–9 obvious (visible through normal usage or basic testing) · 10 public
+(documented, well-known, or immediately apparent).
+
+## Worked examples
+
+**SQL Injection in public-facing API endpoint** (e-commerce, customer database)
+— Damage 10 (full DB compromise, PII + financial theft), Reproducibility 9
+(SQLMap, well-documented), Exploitability 8 (basic SQL, public exploits),
+Affected Users 10 (entire database), Discoverability 9 (OWASP Top 10, scanners).
+**Total 46 → Critical.**
+
+**Insufficient audit logging for admin actions** (internal business app) —
+Damage 6 (undetected malicious activity, forensics/compliance risk),
+Reproducibility 10 (logging present or not), Exploitability 5 (needs legit admin
+access first), Affected Users 7 (impairs incident response for all), 
+Discoverability 6 (needs code/documentation review). **Total 34 → High.**
+
+**Weak password policy** (6 chars, no complexity; consumer web app) — Damage 7,
+Reproducibility 8, Exploitability 7, Affected Users 6, Discoverability 8.
+**Total 36 → High.**
+
+**Missing CSRF protection on a low-impact form** (user preference update) —
+Damage 3, Reproducibility 8, Exploitability 6, Affected Users 4, Discoverability
+7. **Total 28 → Medium.**
+
+**Information disclosure via verbose error messages** (stack traces in
+production) — Damage 5, Reproducibility 7, Exploitability 6, Affected Users 5,
+Discoverability 8. **Total 31 → High.**

--- a/skills/stride-threat-modelling/references/mitigations.md
+++ b/skills/stride-threat-modelling/references/mitigations.md
@@ -1,0 +1,32 @@
+# Mitigations
+
+For each threat — highest priority first — give specific, actionable controls.
+Apply defence-in-depth: prefer layered Preventive + Detective + Corrective
+controls over a single point of failure. Prioritise by risk level and
+implementation difficulty.
+
+## Control categories
+
+- **Preventive** — controls that stop the threat from occurring.
+- **Detective** — controls that detect when the threat occurs.
+- **Corrective** — controls that respond to and recover from the threat.
+
+## Implementation difficulty
+
+- **Easy** — implementable quickly with existing tools/processes.
+- **Medium** — moderate effort, possibly new tools.
+- **Hard** — significant resources, time, or architectural changes.
+
+## Priority
+
+- **High** — critical security controls to implement immediately.
+- **Medium** — important controls to plan for the near term.
+- **Low** — nice-to-have controls for comprehensive defence.
+
+## Guidance
+
+For every High/Critical threat, produce at least one concrete, implementable
+mitigation — not a restatement of the threat. Name the control, its category, its
+difficulty, its priority, and specific implementation guidance for *this* system.
+Implement high-priority preventive controls first, then layer detective and
+corrective controls to close residual risk.

--- a/skills/stride-threat-modelling/references/repo-analysis.md
+++ b/skills/stride-threat-modelling/references/repo-analysis.md
@@ -1,0 +1,48 @@
+# Repository Analysis
+
+When the user points you at a code repository instead of a written description,
+extract the threat-modelling inputs efficiently, then return to the main
+workflow. The aim is **enough context to model threats**, not a complete reading
+of the codebase — every extra file read is wasted context.
+
+## Staged approach
+
+**Stage 1 — Initial (quick scan).** Objective: understand the tech stack,
+architecture, and deployment model. Read **3–5 key files** (e.g. `README`,
+`package.json` / dependency manifest, `docker-compose.yml` / deployment config,
+`.env.example`). Output: tech stack, deployment model, basic architecture.
+*Checkpoint:* after 3–5 reads, STOP and ask — can I identify app type, tech
+stack, and deployment model? If yes, go to Stage 2. If no, read 1–2 more
+specific files.
+
+**Stage 2 — Deep dive.** Objective: extract detailed security context. Perform
+**8–12 targeted searches/reads** on security-critical components only (auth,
+authorization, data handling, external integrations). Output: trust boundaries,
+sensitive data, access controls. *Checkpoint:* after 8–12 searches/reads, STOP
+and ask — can I populate the threat-modelling inputs (app type, auth methods,
+internet-facing, sensitive data, trust boundaries)? If yes, start threat
+modelling. If no, search only for the specific missing information.
+
+**Stage 3 — Validation.** Verify you have sufficient context. Output: a
+readiness assessment, or a short list of remaining gaps to fill.
+
+## Context-management principles
+
+- When in doubt, **search instead of read**.
+- STOP after 3–5 file reads in Stage 1; STOP after 8–12 searches/reads in Stage 2.
+- Don't re-read files — reference earlier reads by file path.
+- Search returns snippets; full reads return entire files.
+- Use **file-path references** in threat descriptions, not pasted code snippets.
+- Don't read for completeness — read until you have enough. More files = wasted
+  context.
+
+## Read vs. search
+
+**Read the full file when:** you need specific configuration values
+(`.env.example`, config files); the file is typically small (`package.json`,
+`docker-compose.yml`, `README`); or you need the complete architecture overview.
+
+**Search when:** looking for patterns (authentication methods, authorization
+checks); examining application code (controllers, services, middleware); the file
+is typically large; or you need to understand *how* something works rather than a
+specific value.

--- a/skills/stride-threat-modelling/references/report-format.md
+++ b/skills/stride-threat-modelling/references/report-format.md
@@ -1,0 +1,70 @@
+# Report Format (House Style)
+
+The deliverable is a Markdown report titled **STRIDE Threat Model Report**.
+Include the sections the user asked for; default to all of them. Populate every
+section with specific analysis from the threat model — never leave the guidance
+prose in place of real content. Each fact must trace back to a threat, DREAD
+score, or mitigation produced during the workflow.
+
+## Section structure
+
+```markdown
+# STRIDE Threat Model Report
+
+## Executive Summary
+- Total threats identified across STRIDE categories
+- Critical and high-priority threats highlighted
+- Key recommendations for immediate action
+- Risk assessment summary
+
+## Application Overview
+Architecture, components, and security-relevant characteristics of the system.
+
+## Threat Analysis
+Threats organised by STRIDE category. For each: Threat ID, description, STRIDE
+category, attack scenarios, potential impact.
+### Spoofing Threats
+### Tampering Threats
+### Repudiation Threats
+### Information Disclosure Threats
+### Denial of Service Threats
+### Elevation of Privilege Threats
+
+## Risk Assessment
+DREAD scores and prioritisation.
+### Critical Priority Threats (DREAD: 40-50)
+### High Priority Threats (DREAD: 30-39)
+### Medium Priority Threats (DREAD: 20-29)
+### Low Priority Threats (DREAD: 5-19)
+
+## Recommended Mitigations
+For each: control type (Preventive/Detective/Corrective), difficulty
+(Easy/Medium/Hard), priority, and specific implementation guidance.
+### High Priority Mitigations
+### Medium Priority Mitigations
+### Low Priority Mitigations
+
+## Security Testing Plan
+Test scenarios per major threat, acceptance criteria, methodology.
+
+## Implementation Roadmap
+- Phase 1 (0-30 days): Critical mitigations
+- Phase 2 (30-90 days): High-priority mitigations
+- Phase 3 (90+ days): Medium and low-priority mitigations
+
+## Appendix
+### Threat Model Data
+Total threats identified; STRIDE coverage breakdown by category.
+### References
+- STRIDE Threat Modeling Methodology
+- DREAD Risk Assessment Framework
+- OWASP Top 10
+- CWE/SANS Top 25
+```
+
+Close with a short footer noting the framework (STRIDE), the risk-scoring method
+(DREAD), and the generation date.
+
+> HTML / printable report output (a self-contained, offline artifact) is tracked
+> separately in issue #12 and will be added here as a delivery reference once
+> built. Until then, produce Markdown.

--- a/skills/stride-threat-modelling/references/security-tests.md
+++ b/skills/stride-threat-modelling/references/security-tests.md
@@ -1,0 +1,55 @@
+# Security Tests
+
+Generate test cases that validate a mitigation actually works. For each targeted
+threat, include at least one **positive** test (control works) and one
+**negative** test (attack is blocked).
+
+## Test types
+
+- **Unit** — test individual security controls in isolation.
+- **Integration** — test security controls working together.
+- **Penetration** — simulate real-world attack scenarios.
+- **Compliance** — verify adherence to security standards.
+
+## Coverage areas
+
+- **Authentication** — identity verification and access controls.
+- **Authorization** — permission and privilege validation.
+- **Input validation** — data sanitization and bounds checking.
+- **Encryption** — data protection in transit and at rest.
+- **Logging** — security event detection and recording.
+
+## Formats
+
+**Gherkin** (default) — Given-When-Then behaviour-driven scenarios:
+
+```gherkin
+Feature: API Authentication
+  Scenario: Unauthorized access attempt
+    Given I am not authenticated
+    When I attempt to access protected endpoint
+    Then I should receive 401 Unauthorized
+    And no sensitive data should be returned
+```
+
+**Checklist** — manual verification steps:
+
+```
+## SQL Injection Testing
+- [ ] Test input validation with SQL metacharacters
+- [ ] Verify parameterized queries are used
+- [ ] Check error messages don't reveal database structure
+- [ ] Test time-based blind injection
+```
+
+**Markdown** — structured test documentation:
+
+```
+### Test Case: XSS Protection
+**Objective**: Verify XSS prevention in user input fields
+**Steps**:
+1. Submit XSS payload in username field
+2. Verify output is properly escaped
+3. Check CSP headers are present
+**Expected**: Script tags rendered as text, not executed
+```

--- a/skills/stride-threat-modelling/references/stride-framework.md
+++ b/skills/stride-threat-modelling/references/stride-framework.md
@@ -1,0 +1,70 @@
+# STRIDE Framework
+
+STRIDE is a systematic methodology for identifying security threats. Each letter
+names a category of threat that violates a specific security property. Apply it
+**per-element**: for every process, data store, data flow, external entity, and
+trust boundary in the system, ask which threats in each category apply.
+
+## The six categories
+
+| | Category | Violates | Description |
+|---|----------|----------|-------------|
+| **S** | Spoofing | Authentication | Impersonating something or someone else |
+| **T** | Tampering | Integrity | Modifying data or code |
+| **R** | Repudiation | Non-repudiation | Claiming to have not performed an action |
+| **I** | Information Disclosure | Confidentiality | Exposing information to unauthorized individuals |
+| **D** | Denial of Service | Availability | Denying or degrading service availability |
+| **E** | Elevation of Privilege | Authorization | Gaining capabilities without proper authorization |
+
+### Threat examples by category
+
+- **Spoofing** — authentication bypass; identity theft/impersonation; credential
+  compromise; session hijacking; certificate/token forgery.
+- **Tampering** — data manipulation/corruption; code injection attacks;
+  configuration modification; message/request tampering; file/database alteration.
+- **Repudiation** — insufficient audit logging; log tampering/deletion;
+  non-repudiation failures; transaction denial; accountability gaps.
+- **Information Disclosure** — unauthorized data access; sensitive information
+  leakage; privacy violations; reconnaissance/enumeration; metadata exposure.
+- **Denial of Service** — resource exhaustion; service flooding/overload;
+  infrastructure disruption; performance degradation; availability attacks.
+- **Elevation of Privilege** — authorization bypass; privilege escalation; access
+  control violations; administrative compromise; permission boundary failures.
+
+## STRIDE-per-element
+
+Enumerate against structure, not from memory. For each element in the system:
+
+1. Identify what the element is (process, data store, data flow, external entity)
+   and which **trust boundaries** it sits on or crosses — a trust boundary is any
+   point where the level of trust changes (user → app, app → database, service →
+   third party, tenant → tenant).
+2. Walk all six STRIDE categories against that element. Record threats that
+   genuinely apply, and mark categories that do not apply as "N/A" **explicitly**
+   — an unrecorded category is a coverage gap, not a decision.
+3. Prefer specific threats ("unauthenticated read of the orders table via the
+   internal reporting API") over generic ones ("SQL injection"). Specificity is
+   what makes the model actionable and repeatable.
+
+Trust boundaries and data flows are where most real threats live — give
+component interfaces, data in transit, and privileged operations extra attention.
+
+## Extended threat domains
+
+Beyond the classic categories, select the domains relevant to the system's
+architecture, technology stack, and deployment model:
+
+- **Traditional web** — SQL injection, XSS, CSRF; authentication/authorization
+  flaws; session management issues; input validation failures.
+- **Cloud infrastructure** — misconfigured services/permissions;
+  container/orchestration vulnerabilities; API gateway security issues;
+  serverless function attacks.
+- **AI/ML systems** — prompt injection; training-data poisoning;
+  model extraction/inversion; adversarial examples; excessive AI agency;
+  AI decision manipulation.
+- **IoT/embedded** — firmware tampering; device impersonation; communication
+  protocol attacks; physical access threats.
+- **Mobile applications** — app tampering/repackaging; device-specific attacks;
+  platform integration issues; local data storage threats.
+- **API/microservices** — service-to-service authentication; API abuse / rate
+  limiting; inter-service communication; service mesh security.


### PR DESCRIPTION
Scaffolds the primary deliverable of #10 — a self-contained Agent Skill that encodes STRIDE-GPT's threat-modelling methodology so any skills-capable client (Claude, Codex, Gemini CLI, Cursor…) produces a consistent, house-style STRIDE threat model with **no API key and no dependency on the MCP server**.

## Structure — per the decisions recorded on #10

- **One model-invoked skill**, not a router or split set. The eight capabilities share a single trigger ("give me a STRIDE threat model"); no independent reach justifies the context-load cost of extra always-loaded descriptions.
- **Methodology inline** in `SKILL.md` (an 8-step STRIDE-per-element workflow, each step with a checkable/exhaustive completion criterion); **heavy reference material progressively disclosed** to `references/`.
- **The skill is the single source of truth** for the methodology — ported from the MCP tool implementations in `api/index.py`, not kept in sync with tool-response strings (that would be the duplication failure mode).

## Contents

| File | Ported from |
|------|-------------|
| `SKILL.md` | orchestration + workflow |
| `references/stride-framework.md` | `get_stride_threat_framework` |
| `references/dread-scoring.md` | `calculate_threat_risk_scores` |
| `references/mitigations.md` | `generate_threat_mitigations` |
| `references/attack-trees.md` | `create_threat_attack_trees` |
| `references/security-tests.md` | `generate_security_tests` |
| `references/coverage-validation.md` | `validate_threat_coverage` |
| `references/report-format.md` | `generate_threat_report` |
| `references/repo-analysis.md` | `get_repository_analysis_guide` |

## Acceptance criteria (#10)

- [x] `SKILL.md` folder with valid frontmatter and a trigger-focused description
- [x] Encodes STRIDE / per-element, threat enumeration, the DREAD rubric, mitigations, attack trees, security tests, and coverage validation as instructions + `references/` — no runtime dependency on the MCP tools
- [x] Produces a consistent house-style STRIDE model + report in Markdown from a system description
- [x] Runs on any skills-capable client with no API key
- [x] Positive-framed, single-source-of-truth, progressive-disclosure per writing-great-skills

## Scaffold status

Methodology content is ported faithfully and the skill is functional. Remaining follow-ups: house-style polish, worked end-to-end example outputs, and the self-contained HTML report artifact (tracked in #12, which is blocked by this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)